### PR TITLE
Update trusted-tag-verifier usage to unified format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,7 @@ jobs:
       - name: Verify Trusted Tag Releaser
         uses: actionutils/trusted-tag-verifier@v0
         with:
-          repository: 'actionutils/trusted-go-releaser'
-          tag: 'v0'
+          verify: 'actionutils/trusted-go-releaser@v0'
 
   # First check if a release is needed
   release-check:


### PR DESCRIPTION
## Summary
- Update workflow to use the new unified verify parameter format

## Changes
- Replace `repository` and `tag` inputs with `verify` input using format `<owner>/<repo>@<version>`

## Related
- Depends on actionutils/trusted-tag-verifier#11

🤖 Generated with [Claude Code](https://claude.ai/code)